### PR TITLE
fix ppc64le issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ARCH = $(shell gcc -dumpmachine)
-CFLAGS = -fPIC -fno-strict-aliasing -W -Wall -Wextra -Wformat -Wno-uninitialized -pipe -g -O2 -DARCH=\"$(ARCH)\" -pthread
+CFLAGS = -fPIC -fno-strict-aliasing -W -Wall -Wextra -Wformat -Wno-uninitialized -pipe -g -DARCH=\"$(ARCH)\" -pthread
 TARGET = fsp-trace 
 
 all:	$(TARGET)

--- a/copyright.c
+++ b/copyright.c
@@ -19,5 +19,5 @@
 
 
 static const char copyright [] __attribute__((unused))
-                               __attribute__((section (".comment"))) =
+                               __attribute__((section (".legal"))) =
 	"Licensed under the Apache License, Version 2.0.\n";


### PR DESCRIPTION
Currently we can compile fsp-trace, but it doesn't work. Disabling optimisations and moving the apache license information out of the .comment section to fix a linker issue seems to fix it.